### PR TITLE
Put wrapper container in its own stacking context

### DIFF
--- a/packages/core/src/container/ReactFlow/index.tsx
+++ b/packages/core/src/container/ReactFlow/index.tsx
@@ -53,8 +53,9 @@ const initDefaultViewport: Viewport = { x: 0, y: 0, zoom: 1 };
 const wrapperStyle: CSSProperties = {
   width: '100%',
   height: '100%',
-  position: 'relative',
   overflow: 'hidden',
+  position: 'relative',
+  zIndex: 0,
 };
 
 const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(


### PR DESCRIPTION
This would put the wrapper and its content in "isolation" so their `z-index` wouldn't overflow to outside of the container.

Before (black pane is non react flow UI, which is not interactable because the cursor is also the grabbing hand moving the canvas behind):

![image](https://user-images.githubusercontent.com/9028430/195887974-d064ff09-8d99-495d-ab13-8f17c3d7384d.png)

After (black pane is interactable and the controls are now behind it):

<img width="394" alt="image" src="https://user-images.githubusercontent.com/9028430/195888102-0e690527-6350-4467-b24e-d31d549187c7.png">

